### PR TITLE
fix: consider the keepInvalid flag

### DIFF
--- a/src/ng-tempusdominus-bootstrap.directive.ts
+++ b/src/ng-tempusdominus-bootstrap.directive.ts
@@ -151,8 +151,8 @@ export class NgTempusdominusBootstrapInputDirective implements OnInit, OnDestroy
             if (e.date && e.date !== this.value) {
                 this.value = e.date || null;
             } else {
-                const date = _moment(e.target.value, this.options.format);
-                if (date.isValid()) {
+                const date = _moment(e.target.value, this.options.format, this.options.useStrict || false);
+                if (date.isValid() || this.options.keepInvalid) {
                     this.value = date;
                 }
             }


### PR DESCRIPTION
First, thanks for your great job doing this library.
I hope you could still be interested by some fixes.

I noticed that the `keepInvalid` flag is not considered when the datepicker received a new date. Besides that, the `useStrict` flag will also be used if defined to format the date